### PR TITLE
Markdown を Syntax Highlight で表示するように修正

### DIFF
--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -3,6 +3,7 @@ import Router from "./router/router";
 import Header from "./container/Header.vue";
 import Vuetify from "vuetify";
 import "vuetify/dist/vuetify.min.css";
+import "highlight.js/styles/monokai.css";
 
 Vue.use(Vuetify);
 

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -18,6 +18,7 @@ import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import TimeAgo from 'vue2-timeago';
 import marked from "marked";
+import hljs from "highlight.js";
 
 @Component({
   components: {
@@ -28,6 +29,36 @@ export default class ArticleContainer extends Vue {
   article: any = "";
   async mounted(): Promise<void> {
     await this.fetchArticle(this.$route.params.id);
+  }
+
+  async created(): Promise<void> {
+    // Add 'hljs' class to code tag
+    const renderer = new marked.Renderer();
+    renderer.code = function(code, language) {
+      return (
+        "<pre" +
+        '><code class="hljs">' +
+        hljs.highlightAuto(code).value +
+        "</code></pre>"
+      );
+    };
+    marked.setOptions({
+      renderer: renderer,
+      tables: true,
+      sanitize: true,
+      langPrefix: "",
+      highlight: function(code, lang) {
+        if (!lang || lang == "default") {
+          return hljs.highlightAuto(code, [lang]).value;
+        } else {
+          try {
+            return hljs.highlight(lang, code, true).value;
+          } catch (e) {
+            // Do nonthing!
+          }
+        }
+      }
+    });
   }
 
   get compiledMarkdown() {

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -8,7 +8,7 @@
       <h1 class="article-title">{{ article.title }}</h1>
     </v-layout>
     <v-layout class="article-body-container">
-      <div id="article-body">{{ article.body }}</div>
+      <div id="article-body" v-html="compiledMarkdown"></div>
     </v-layout>
   </v-container>
 </template>
@@ -16,7 +16,8 @@
 <script lang="ts">
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
-import TimeAgo from 'vue2-timeago'
+import TimeAgo from 'vue2-timeago';
+import marked from "marked";
 
 @Component({
   components: {
@@ -28,6 +29,11 @@ export default class ArticleContainer extends Vue {
   async mounted(): Promise<void> {
     await this.fetchArticle(this.$route.params.id);
   }
+
+  get compiledMarkdown() {
+    return marked(this.article.body);
+  }
+
   async fetchArticle(id: string): Promise<void> {
     await axios
       .get(`/api/v1/articles/${id}`)
@@ -47,7 +53,7 @@ export default class ArticleContainer extends Vue {
   margin-bottom: 1em;
 }
 .article-container {
-  margin: 2em;
+  margin-top: 2em;
 }
 .article-title {
   font-size: 2.5em;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
     "axios": "^0.19.0",
+    "highlight.js": "^9.15.8",
     "marked": "^0.6.2",
     "ts-loader": "^6.0.3",
     "typescript": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
     "axios": "^0.19.0",
+    "marked": "^0.6.2",
     "ts-loader": "^6.0.3",
     "typescript": "^3.5.2",
     "vee-validate": "^2.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,6 +3747,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highlight.js@^9.15.8:
+  version "9.15.10"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
+  integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,6 +4633,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marked@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.3.tgz#79babad78af638ba4d522a9e715cdfdd2429e946"
+  integrity sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"


### PR DESCRIPTION
以下のように対応しました。
ご確認をお願いします。

## 概要
記事本文を、Markdown記法・Syntax Highlight で投稿できるように設定

使用したライブラリ
- [marked.js](https://github.com/markedjs/marked)
- [highlight.js](https://github.com/highlightjs/highlight.js/)

![image](https://user-images.githubusercontent.com/33590509/66847940-304a4600-efaf-11e9-8936-ab741a27884b.png)

