### PR TITLE
Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -21,4 +21,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+
+  enum status: [:draft, :public]
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,5 +22,5 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  enum status: [:draft, :public]
+  enum status: {draft: 0, publish: 1}
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,5 +22,5 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  enum status: {draft: 0, publish: 1}
+  enum status: { draft: 0, publish: 1 }
 end

--- a/db/migrate/20191016151309_add_status_to_articles.rb
+++ b/db/migrate/20191016151309_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :status, :integer, default: 0, null: false, limit: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_04_082831) do
+ActiveRecord::Schema.define(version: 2019_10_16_151309) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2019_10_04_082831) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.integer "status", limit: 1, default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe Article, type: :model do
         expect(article).to be_valid
       end
     end
+    context "下書き記事を作成する時" do
+      it "作成できる" do
+        article = create(:article, status: "draft")
+        binding.pry
+        expect(article).to be_valid
+      end
+    end
+    context "公開記事を作成する時" do
+      it "作成できる" do
+        article = create(:article, status: "publish")
+        binding.pry
+        expect(article).to be_valid
+      end
+    end
   end
   describe "異常系" do
     context "タイトルが入力されていない時" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -25,14 +25,12 @@ RSpec.describe Article, type: :model do
     context "下書き記事を作成する時" do
       it "作成できる" do
         article = create(:article, status: "draft")
-        binding.pry
         expect(article).to be_valid
       end
     end
     context "公開記事を作成する時" do
       it "作成できる" do
         article = create(:article, status: "publish")
-        binding.pry
         expect(article).to be_valid
       end
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -17,21 +17,17 @@ require "rails_helper"
 RSpec.describe Article, type: :model do
   describe "正常系" do
     context "タイトルと本文が入力されている時" do
-      it "登録出来る" do
-        article = create(:article)
+      let(:article) { create(:article) }
+      it "登録出来る(ステータスは下書き)" do
         expect(article).to be_valid
-      end
-    end
-    context "下書き記事を作成する時" do
-      it "作成できる" do
-        article = create(:article, status: "draft")
-        expect(article).to be_valid
+        expect(article.status).to eq "draft"
       end
     end
     context "公開記事を作成する時" do
+      let(:article) { create(:article, status: "publish") }
       it "作成できる" do
-        article = create(:article, status: "publish")
         expect(article).to be_valid
+        expect(article.status).to eq "publish"
       end
     end
   end


### PR DESCRIPTION
以下のように対応しました。
ご確認をお願いします。

## 概要
1. article modelへ status カラム追加
1. article model へ enum を定義
1. article モデルテスト
