### PR TITLE
articles controller の修正（本番公開と下書きのステータス追加）

### DIFF
--- a/app/controllers/api/v1/article_preview_serializer.rb
+++ b/app/controllers/api/v1/article_preview_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :updated_at
+  attributes :id, :title, :updated_at, :status
   belongs_to :user
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -5,12 +5,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :set_article, only: %i[update destroy]
 
   def index
-    articles = Article.order(updated_at: :desc)
+    articles = Article.publish.order(updated_at: :desc)
     render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.publish.find(params[:id])
     render json: article
   end
 
@@ -31,7 +31,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   private
 
   def article_params
-    params.require(:article).permit(:title, :body)
+    params.require(:article).permit(:title, :body, :status)
   end
 
   def set_article

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -16,6 +16,12 @@ FactoryBot.define do
   factory :article do
     title { Faker::Book.title }
     body { Faker::TvShows::Friends.quote }
+    status { :publish }
     user
+
+    trait :draft_status do
+      status { :draft }
+      user
+    end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -16,11 +16,14 @@ FactoryBot.define do
   factory :article do
     title { Faker::Book.title }
     body { Faker::TvShows::Friends.quote }
-    status { :publish }
+    status { :draft }
     user
 
     trait :draft_status do
       status { :draft }
+    end
+    trait :publish_status do
+      status { :publish }
     end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -21,7 +21,6 @@ FactoryBot.define do
 
     trait :draft_status do
       status { :draft }
-      user
     end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -17,14 +17,14 @@ require "rails_helper"
 RSpec.describe Article, type: :model do
   describe "正常系" do
     context "タイトルと本文が入力されている時" do
-      let(:article) { create(:article) }
+      let(:article) { create(:article, :draft_status) }
       it "登録出来る(ステータスは下書き)" do
         expect(article).to be_valid
         expect(article.status).to eq "draft"
       end
     end
     context "公開記事を作成する時" do
-      let(:article) { create(:article, status: "publish") }
+      let(:article) { create(:article, :publish_status) }
       it "作成できる" do
         expect(article).to be_valid
         expect(article.status).to eq "publish"

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -22,10 +22,12 @@ RSpec.describe "Articles", type: :request do
     end
 
     context "下書きの記事がある時" do
-      let!(:article) { create(:article, status: "draft") }
+      let(:article) { create(:article, status: "draft") }
 
-      it "記事一覧を取得できない" do
-        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      it "下書きの一覧は、取得できない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res).to be_empty
       end
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "Articles", type: :request do
     subject { get(api_v1_articles_path) }
 
     context "公開済みの記事がある時" do
-      let!(:article1) { create(:article, updated_at: 1.day.ago) }
-      let!(:article2) { create(:article, updated_at: 2.days.ago) }
-      let!(:article3) { create(:article) }
+      let!(:article1) { create(:article, :publish_status, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, :publish_status, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :publish_status) }
       let!(:article4) { create(:article, :draft_status) }
 
       it "公開済みの一覧のみ取得できる(更新順)" do
@@ -26,7 +26,7 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
     context "公開済みで、存在する記事の詳細を指定した時" do
-      let(:article) { create(:article) }
+      let(:article) { create(:article, :publish_status) }
       let(:article_id) { article.id }
 
       it "記事が表示される" do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe "Articles", type: :request do
     subject { get(api_v1_articles_path) }
 
     context "公開済みの記事がある時" do
-      let!(:article1) { create(:article, updated_at: 1.day.ago, status: "publish") }
-      let!(:article2) { create(:article, updated_at: 2.days.ago, status: "publish") }
-      let!(:article3) { create(:article, status: "publish") }
+      let!(:article1) { create(:article, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article) }
+      let!(:article4) { create(:article, :draft_status) }
 
-      it "一覧を全て取得できる(更新順)" do
+      it "公開済みの一覧のみ取得できる(更新順)" do
         subject
         res = JSON.parse(response.body)
         expect(res.length).to eq 3
@@ -20,22 +21,12 @@ RSpec.describe "Articles", type: :request do
         expect(response).to have_http_status(200)
       end
     end
-
-    context "下書きの記事がある時" do
-      let(:article) { create(:article, status: "draft") }
-
-      it "下書きの一覧は、取得できない" do
-        subject
-        res = JSON.parse(response.body)
-        expect(res).to be_empty
-      end
-    end
   end
 
   describe "GET /articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
     context "公開済みで、存在する記事の詳細を指定した時" do
-      let(:article) { create(:article, status: "publish") }
+      let(:article) { create(:article) }
       let(:article_id) { article.id }
 
       it "記事が表示される" do
@@ -55,7 +46,7 @@ RSpec.describe "Articles", type: :request do
       end
     end
     context "下書きの記事の詳細を指定した時" do
-      let(:article) { create(:article, status: "draft") }
+      let(:article) { create(:article, :draft_status) }
       let(:article_id) { article.id }
 
       it "記事が表示されない" do


### PR DESCRIPTION
以下のように対応しました。
ご確認をお願いします。

## 概要
1. article_controller status 部分修正
1. serializer に status カラム追加
1. article_controller テスト実装

### 質問
「下書きの記事がある時、記事一覧を取得できない」のテストで、エラーが発生してしまいます。
以下のようにデバックしてみたのですが、手詰まりになってしまいました。
お手すきの際に、ご確認いただけますでしょうか。

以下がエラーの部分です。

```ruby
2019-10-17 23:15:42 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.

Articles
  GET /articles
    公開済みの記事がある時
      一覧を全て取得できる(更新順)
    下書きの記事がある時
      記事一覧を取得できない (FAILED - 1)
  GET /articles/:id
    公開済みで、存在する記事の詳細を指定した時
      記事が表示される
    存在しない記事の詳細を指定した時
      記事が表示されない
    下書きの記事の詳細を指定した時
      記事が表示されない
  POST /articles
    記事が作成出来る
  PATCH /articles/:id
    自分の記事を更新する時
      自分の記事のタイトルと本文のみが正しく更新される
    他人の記事を更新する時
      更新出来ない（見つからない）
  DELETE /articles/:id
    自分の記事を削除する時
      任意の記事が削除出来ている
    他人の記事を削除する時
      削除出来ない（見つからない）

Failures:

  1) Articles GET /articles 下書きの記事がある時 記事一覧を取得できない
     Failure/Error: expect { subject }.to raise_error ActiveRecord::RecordNotFound
       expected ActiveRecord::RecordNotFound but nothing was raised
     # ./spec/requests/api/v1/articles_spec.rb:29:in `block (4 levels) in <top (required)>'
```

以下、デバッグしてみたのですが、subject のレスポンスが 200 で返ってきてしまいます。
```ruby
From: /Users/mayuhirota/git/qiita_clone/spec/requests/api/v1/articles_spec.rb @ line 29 :

    24:     context "下書きの記事がある時" do
    25:       let!(:article) { create(:article, status: "draft") }
    26: 
    27:       it "記事一覧を取得できない" do
    28:         binding.pry
 => 29:         expect { subject }.to raise_error ActiveRecord::RecordNotFound
    30:       end
    31:     end
    32:   end
    33: 
    34:   describe "GET /articles/:id" do

[1] pry(#<RSpec::ExampleGroups::Articles::GETArticles::Nested_2>)> subject
=> 200
```

コントローラの方で止めてみたのですが、想定どおり値は取れておらず、なぜ 200 が返ってくるかわからず、手詰まりになってしまいました・・・お手すきの際、ご確認いただけますでしょうか。
```ruby
     7: def index
     8:   articles = Article.publish.order(updated_at: :desc)
    9:   binding.pry
 => 10:   render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
    11: end

[1] pry(#<Api::V1::ArticlesController>)> articles
=> []
```
