### PR TITLE
マイページの追加

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Current::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!
 
   def index
-    articles = current_user.articles.published.order(updated_at: :desc)
-    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    articles = current_user.articles.published.order(created_at: :desc)
+    render json: articles, each_serializer: Api::V1::Current::ArticlePreviewSerializer
   end
 end

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -4,17 +4,24 @@
       <v-toolbar-title class="white--text font-weight-bold">Qiita</v-toolbar-title>
     </router-link>
 
-    <!-- <v-btn icon>
-      <v-icon>search</v-icon>
-    </v-btn>-->
-
     <v-spacer></v-spacer>
 
     <div v-if="isLoggedIn">
       <router-link to="/articles/new" class="header-link">
         <v-btn flat class="post font-weight-bold">投稿する</v-btn>
       </router-link>
-      <v-btn flat @click="logout" class="white--text font-weight-bold">ログアウト</v-btn>
+      <v-menu bottom left min-width="120">
+        <template v-slot:activator="{ on }">
+          <v-btn dark icon v-on="on">
+            <v-icon>more_vert</v-icon>
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-tile v-for="(menu, i) in menus" :key="i" @click="undefined">
+            <v-list-tile-title @click="menu.click">{{ menu.title }}</v-list-tile-title>
+          </v-list-tile>
+        </v-list>
+      </v-menu>
     </div>
     <div v-else>
       <router-link to="/sign_up" class="header-link">
@@ -31,6 +38,7 @@
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import Router from "../router/router";
+
 const headers = {
   headers: {
     Authorization: "Bearer",
@@ -40,9 +48,37 @@ const headers = {
     uid: localStorage.getItem("uid")
   }
 };
+
 @Component
 export default class Header extends Vue {
   isLoggedIn: boolean = !!localStorage.getItem("access-token");
+  items: any = [
+    { title: "Menu" },
+    { title: "Menu" },
+    { title: "Menu" },
+    { title: "Menu" }
+  ];
+  menus: any = [
+    {
+      title: "マイページ",
+      click: () => {
+        this.moveToMyPage();
+      }
+    },
+    {
+      title: "下書き一覧",
+      click: () => {
+        this.moveToDrafts();
+      }
+    },
+    {
+      title: "ログアウト",
+      click: () => {
+        this.logout();
+      }
+    }
+  ];
+
   async logout(): Promise<void> {
     await axios
       .delete("/api/v1/auth/sign_out", headers)
@@ -57,6 +93,14 @@ export default class Header extends Vue {
         this.refresh();
       });
   }
+  moveToMyPage(): void {
+    Router.push("/mypage");
+  }
+
+  moveToDrafts(): void {
+    Router.push("/articles/drafts");
+  }
+
   private refresh(): void {
     localStorage.clear();
     Router.push("/");

--- a/app/javascript/packs/container/MyPageContainer.vue
+++ b/app/javascript/packs/container/MyPageContainer.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-container class="item elevation-3 articles-container">
+    <h2>最近書いた記事</h2>
+    <v-list two-line>
+      <template v-for="(article, index) in articles">
+        <v-list-tile :key="article.title" avatar>
+          <v-list-tile-avatar>
+            <img :src="article.avatar" />
+          </v-list-tile-avatar>
+
+          <v-list-tile-content>
+            <v-list-tile-title class="article-title">
+              <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
+            </v-list-tile-title>
+            <v-list-tile-sub-title>
+              by {{ article.user.name }}
+              <time-ago
+                :refresh="60"
+                :datetime="article.updated_at"
+                locale="en"
+                tooltip="right"
+                long
+              ></time-ago>
+            </v-list-tile-sub-title>
+          </v-list-tile-content>
+        </v-list-tile>
+        <v-divider :key="index"></v-divider>
+      </template>
+    </v-list>
+  </v-container>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import TimeAgo from "vue2-timeago";
+import Router from "../router/router";
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+@Component({
+  components: {
+    TimeAgo
+  }
+})
+export default class MyPageContainer extends Vue {
+  articles: string[] = [];
+  async mounted(): Promise<void> {
+    await this.fetchArticles();
+  }
+  async fetchArticles(): Promise<void> {
+    await axios.get("/api/v1/current/articles", headers).then(response => {
+      response.data.map((article: any) => {
+        this.articles.push(article);
+      });
+    });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.articles-container {
+  margin-top: 2em;
+  .article-title {
+    a {
+      color: #000;
+      font-weight: bold;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    a:visited {
+      color: #777;
+    }
+  }
+}
+</style>

--- a/app/javascript/packs/container/MyPageContainer.vue
+++ b/app/javascript/packs/container/MyPageContainer.vue
@@ -13,7 +13,7 @@
               <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
             </v-list-tile-title>
             <v-list-tile-sub-title>
-              by {{ article.user.name }}
+              by {{ article.user.account }}
               <time-ago
                 :refresh="60"
                 :datetime="article.created_at"

--- a/app/javascript/packs/container/MyPageContainer.vue
+++ b/app/javascript/packs/container/MyPageContainer.vue
@@ -16,11 +16,12 @@
               by {{ article.user.name }}
               <time-ago
                 :refresh="60"
-                :datetime="article.updated_at"
+                :datetime="article.created_at"
                 locale="en"
                 tooltip="right"
                 long
               ></time-ago>
+              <span>に投稿</span>
             </v-list-tile-sub-title>
           </v-list-tile-content>
         </v-list-tile>

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -5,6 +5,7 @@ import ArticleContainer from '../container/ArticleContainer.vue';
 import RegisterContainer from '../container/RegisterContainer.vue';
 import LoginContainer from "../container/LoginContainer.vue";
 import EditArticleContainer from "../container/EditArticleContainer.vue";
+import MyPageContainer from "../container/MyPageContainer.vue";
 
 Vue.use(VueRouter)
 
@@ -16,6 +17,7 @@ export default new VueRouter({
     { path: "/sign_in", component: LoginContainer },
     { path: "/articles/new", component: EditArticleContainer },
     { path: "/articles/:id/edit", component: EditArticleContainer },
-    { path: "/articles/:id", component: ArticleContainer, name: "article" }
+    { path: "/articles/:id", component: ArticleContainer, name: "article" },
+    { path: "/mypage", component: MyPageContainer }
   ]
 })

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -2,5 +2,5 @@
 
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
   attributes :id, :title, :updated_at, :status
-  belongs_to :user
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -2,5 +2,5 @@
 
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :updated_at
-  belongs_to :user
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/current/article_preview_serializer.rb
+++ b/app/serializers/api/v1/current/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::Current::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :created_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/current/article_preview_serializer.rb
+++ b/app/serializers/api/v1/current/article_preview_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Api::V1::Current::ArticlePreviewSerializer < ActiveModel::Serializer
   attributes :id, :title, :created_at
   belongs_to :user, serializer: Api::V1::UserSerializer

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :account, :email
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Api::V1::UserSerializer < ActiveModel::Serializer
   attributes :id, :account, :email
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "articles/new", to: "homes#index"
   get "articles/:id/edit", to: "homes#index"
   get "articles/:id", to: "homes#index"
+  get "articles/mypage", to: "homes#index"
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get "articles/new", to: "homes#index"
   get "articles/:id/edit", to: "homes#index"
   get "articles/:id", to: "homes#index"
-  get "articles/mypage", to: "homes#index"
+  get "mypage", to: "homes#index"
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
     context "マイページにアクセスした時" do
       let(:headers) { authentication_headers_for(current_user) }
       let(:current_user) { create(:user) }
-      let!(:article1) { create(:article, :published_status, user: current_user, updated_at: 1.day.ago) }
-      let!(:article2) { create(:article, :published_status, user: current_user, updated_at: 2.days.ago) }
+      let!(:article1) { create(:article, :published_status, user: current_user, created_at: 10.days.ago, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, :published_status, user: current_user, created_at: 3.days.ago, updated_at: 2.days.ago) }
       let!(:article3) { create(:article, :published_status, user: current_user) }
       let!(:article4) { create(:article, :draft_status, user: current_user) }
 
@@ -19,7 +19,7 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
         res = JSON.parse(response.body)
         aggregate_failures "testing response" do
           expect(res.length).to eq 3
-          expect(res.map { |d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+          expect(res.map { |d| d["id"] }).to eq [article3.id, article2.id, article1.id]
           expect(res[0]["title"]).to eq article3.title
           expect(res[0]["user"]["id"]).to eq current_user.id
           expect(res[0]["user"]["account"]).to eq current_user.account


### PR DESCRIPTION
以下のように対応しました。
ご確認をお願いします。

## 概要
1. ヘッダー修正
1. マイページ追加
    - ログイン中のユーザーの記事一覧が出るように実装
    - 記事一覧が作成順になるように修正
    - 更新日ではなく、作成日を表示するよう修正
1. 記事一覧部分のテスト修正

![image](https://user-images.githubusercontent.com/33590509/67362458-080da900-f5a6-11e9-9a90-7426cd32e204.png)





